### PR TITLE
Fixed concat dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "cmc-curator",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "author": "Conclusion Mission Critical",
   "license": "Apache-2.0",
   "summary": "Installs elasticsearch curator",
@@ -14,6 +14,6 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.2.0 <7.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">=4.0.0 <5.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=4.0.0 <7.0.0" }
   ]
 }


### PR DESCRIPTION
Gecontroleerd wat er veranderd is. Heeft geen impact op ons.
* Van 4.x. naar 5.x is support voor Debian 7 en Scientific Linux 5 verwijderd
* Van 5.x naar 6.x is de lower boundry van Puppet verhoogt naar 5.5.10